### PR TITLE
Switch to proper permission `idle-detection`

### DIFF
--- a/idle-detector.html
+++ b/idle-detector.html
@@ -9,7 +9,7 @@
     document.getElementById(target).appendChild(document.createElement('br'));
   }
   async function main() {
-    const hasPermission = await navigator.permissions.query({ name: 'notifications' });
+    const hasPermission = await navigator.permissions.query({ name: 'idle-detection' });
     if (hasPermission.state !== 'granted') {
       const result = await Notification.requestPermission();
       if (result !== 'granted') {


### PR DESCRIPTION
Permission for `IdleDetector` changed from `notifications` to `idle-detection` in the CL [idle-detection: Implement permissions prompt and settings UI](https://chromium-review.googlesource.com/c/chromium/src/+/2360485)